### PR TITLE
Carls logstash forwarder fixes

### DIFF
--- a/blues/logstash.py
+++ b/blues/logstash.py
@@ -41,8 +41,6 @@ is_server = lambda: blueprint.get('server') is not None
 is_client = lambda: blueprint.get('forwarder') is not None
 
 
-
-
 @task
 def setup():
     """
@@ -157,7 +155,7 @@ def create_server_ssl_cert():
 
 
 def download_server_ssl_cert(destination='ssl/'):
-    blueprint.download(LOGSTASH_CERT_PATH, destination)
+    blueprint.download('/etc/pki/tls/certs/logstash-forwarder.crt', destination)
 
 
 def configure_server(config, auto_disable_conf=True, **context):

--- a/blues/logstash.py
+++ b/blues/logstash.py
@@ -219,7 +219,10 @@ def install_forwarder():
 
         info('Installing {}', 'logstash forwarder')
         debian.apt_get('update')
-        debian.apt_get('install', 'logstash-forwarder')
+
+        # Since deprecating logstash-forwarder in favour of filebeat, the repo
+        # key is no longer available and installs must be forced.
+        debian.apt_get('install', '--force-yes', 'logstash-forwarder')
 
         # Upload init script
         blueprint.upload('forwarder/init.d/logstash-forwarder', '/etc/init.d/')

--- a/blues/templates/logstash/forwarder/init.d/logstash-forwarder
+++ b/blues/templates/logstash/forwarder/init.d/logstash-forwarder
@@ -17,7 +17,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="log shipper"
 NAME=logstash-forwarder
 DAEMON=/opt/logstash-forwarder/bin/logstash-forwarder
-DAEMON_ARGS="-config /etc/logstash-forwarder -spool-size 100 -log-to-syslog"
+DAEMON_ARGS="-config /etc/logstash-forwarder.conf -spool-size 100 -log-to-syslog"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/blues/templates/logstash/forwarder/logstash-forwarder.template
+++ b/blues/templates/logstash/forwarder/logstash-forwarder.template
@@ -1,9 +1,8 @@
 {
   "network": {
-    "servers": [ {{ servers }} ],
-    "timeout": 15{% if use_ssl %},
-    "ssl ca": "/etc/pki/tls/certs/logstash-forwarder.crt"
-    {%- endif %}
+    "servers": [ {{ servers }} ]
+    , "timeout": 15
+    {% if use_ssl %}, "ssl ca": "/etc/pki/tls/certs/logstash-forwarder.crt"{%- endif %}
   },
   "files": {% block files %}{% endblock %}
 }


### PR DESCRIPTION
* Changed config file to standard path: /etc/logstash-forwarder.conf
* Ensure cert path exists before attempting upload
* Add support for log types
* Add support for multiple logfile paths per file group
* Force installation to get around the lack of a current repo pubkey