### PR TITLE
Major rewrite of celery/supervisor configuration

### DIFF
--- a/blues/app.py
+++ b/blues/app.py
@@ -75,10 +75,10 @@ from refabric.contrib import blueprints
 blueprint = blueprints.get(__name__)
 
 from .application.tasks import setup, configure, deploy, deployed, start, stop,\
-    reload, configure_providers, generate_nginx_conf, notify_deploy, \
+    reload, status, configure_providers, generate_nginx_conf, notify_deploy, \
     install_requirements, notify_deploy_start
 
 from .application.deploy import update_source
 
 __all__ = ['setup', 'configure', 'deploy', 'deployed', 'start', 'stop',
-           'reload', 'configure_providers', 'generate_nginx_conf', 'install_requirements']
+           'reload', 'status', 'configure_providers', 'generate_nginx_conf', 'install_requirements']

--- a/blues/application/managers/supervisor.py
+++ b/blues/application/managers/supervisor.py
@@ -72,3 +72,12 @@ class SupervisorManager(BaseManager):
 
     def reload(self, program=None):
         supervisor.reload(program)
+
+    def start(self, program=None):
+        supervisor.start(program)
+
+    def stop(self, program=None):
+        supervisor.stop(program)
+
+    def status(self, program=None):
+        supervisor.status(program)

--- a/blues/application/tasks.py
+++ b/blues/application/tasks.py
@@ -149,6 +149,16 @@ def reload():
 
 
 @task
+def status():
+    """
+    get status from all application providers on current host
+    """
+    providers = get_providers(env.host_string)
+    for provider in set(providers.values()):
+        provider.status()
+
+
+@task
 def configure_providers(force_reload=False):
     """
     Render, upload and reload web & worker config

--- a/blues/supervisor.py
+++ b/blues/supervisor.py
@@ -28,10 +28,10 @@ import os
 from fabric.context_managers import cd
 from fabric.contrib import files
 from fabric.decorators import task
-from fabric.utils import warn
+from fabric.utils import puts, warn
 
 from refabric.api import run, info
-from refabric.context_managers import sudo, silent, hide_prefix
+from refabric.context_managers import sudo, silent
 from refabric.contrib import blueprints
 
 from . import debian
@@ -220,9 +220,10 @@ def ctl(command, program=''):
     :param program: The program to run command against
     """
     with silent():
+        puts('supervisorctl {} {}'.format(command, program))
         output = supervisorctl(command, program=program)
-        with hide_prefix():
-            info(output)
+        for line in output.split('\n'):
+            info(line)
 
 
 @task

--- a/blues/templates/app/supervisor/default/celery.conf
+++ b/blues/templates/app/supervisor/default/celery.conf
@@ -1,20 +1,25 @@
 {%- if not queues %}
-{% extends 'supervisor/default/program.conf' %}
-{% block program_name -%}celery{% endblock program_name -%}
 
-    {% block program -%}
+{% extends 'supervisor/default/program.conf' %}
+{% block program_name -%}worker{% endblock program_name -%}
+{% block program -%}
 # Start before celery beat
 priority=998
 command={{ virtualenv }}/bin/celery worker --app={{ module }} -l info -c {{ workers }}
-    {%- endblock program %}
+
+[group:celery_worker]
+programs=worker
+
+{%- endblock program %}
+
 {% else %}
-    {%- set filtered_queue = [] -%}
-    {% for queue_name, queue in queues.iteritems() -%}
-        {%- set program_name = queue_name %}
+
+    {% for program_name, queue in queues.iteritems() %}
 {% include 'supervisor/default/program.conf' %}
-command={{ virtualenv }}/bin/celery worker --app={{ module }} -c {{ queue.workers }} -Q {{ queue_name }} -E -n {{ queue_name}}-worker@%%h -l info
-        {% if filtered_queue.append(program_name) -%}{%- endif %}
-    {%- endfor %}
-[group:celeryd]
-programs={{ filtered_queue|join(',') }}
+command={{ virtualenv }}/bin/celery worker --app={{ module }} -c {{ queue.workers }} -Q {{ program_name }} -E -n {{ program_name}}-worker@%%h -l info
+    {% endfor %}
+
+[group:celery_worker]
+programs={{ queues.keys()|join(',') }}
+
 {% endif -%}


### PR DESCRIPTION
Should fix the rogues-workers problem, along with other changes to celery worker management.
Operations run against an app with the `celery` provider now properly target the specific supervisor program group, without affecting the supervisord process itself.

New commands have been added to `app`, it can be stopped, started or queried for status (so far only for supervisor manager, uwsgi will follow eventually.) I hope we can move away from requiring knowledge of the provider/manager to perform basic app tasks.

This will require running `supervisor.configure` and `supervisor.reload` manually after merging to apply the new naming convention for the program group.