### PR TITLE
Deploy to tags

### DIFF
--- a/blues/app.py
+++ b/blues/app.py
@@ -76,9 +76,10 @@ blueprint = blueprints.get(__name__)
 
 from .application.tasks import setup, configure, deploy, deployed, start, stop,\
     reload, status, configure_providers, generate_nginx_conf, notify_deploy, \
-    install_requirements, notify_deploy_start
+    install_requirements, notify_deploy_start, get_latest_release
 
 from .application.deploy import update_source
 
 __all__ = ['setup', 'configure', 'deploy', 'deployed', 'start', 'stop',
-           'reload', 'status', 'configure_providers', 'generate_nginx_conf', 'install_requirements']
+           'reload', 'status', 'configure_providers', 'generate_nginx_conf',
+           'install_requirements', 'get_latest_release', 'update_source']

--- a/blues/application/deploy.py
+++ b/blues/application/deploy.py
@@ -351,29 +351,27 @@ def install_source():
     return cloned
 
 
-def update_source():
+def update_source(revision=None):
     """
-    Update application repository with configured branch.
+    Update application repository to the specified revision.
 
     :return: tuple(previous commit, current commit)
     """
-    from .project import sudo_project, git_repository_path, git_repository
+    from .project import sudo_project, git_repository_path, remote_head
+
+    if not revision:
+        branch, revision = remote_head()
+        warn('No revision specified, assuming {} (from: {})'.format(revision, branch))
 
     with sudo_project():
         # Get current commit
-        path = git_repository_path()
-        previous_commit = git.get_commit(path, short=True)
+        repository_path = git_repository_path()
+        previous_commit = git.get_commit(repository_path, short=True)
 
         # Update source from git (reset)
-        repository = git_repository()
-        current_commit = git.reset(repository['branch'],
-                                   repository_path=path,
+        current_commit = git.reset(repository_path=repository_path,
+                                   revision=revision,
                                    ignore=blueprint.get('git_force_ignore'))
-
-        if current_commit is not None and current_commit != previous_commit:
-            info(indent('(new version)'))
-        else:
-            info(indent('(same commit)'))
 
         return previous_commit, current_commit
 

--- a/blues/application/deploy.py
+++ b/blues/application/deploy.py
@@ -183,7 +183,6 @@ def maybe_install_requirements(previous_commit, current_commit, force=False, upd
                 installation_file)
 
     if has_changed or force:
-        info('Install requirements {}', installation_file)
         install_requirements(installation_file, update_pip=update_pip)
     else:
         info(indent('(requirements not changed in {}...skipping)'),
@@ -280,6 +279,11 @@ def diff_requirements_smart(previous_commit, current_commit, filename,
 
 
 def get_installation_method(filename):
+    """
+    Guess installation method from the requirements file
+
+    :return: 'pip' or 'setuptools'
+    """
     if filename.endswith('.txt') or \
             filename.endswith('.pip'):
         return 'pip'
@@ -300,18 +304,20 @@ def install_requirements(installation_file=None, update_pip=False):
     with sudo_project():
         path = virtualenv_path()
 
-        info('Installing requirements from file {}', installation_file)
-
         with virtualenv.activate(path):
             installation_method = get_installation_method(installation_file)
             if update_pip:
-                python.update_pip()
+                python.update_pip(quiet=True)
 
             if installation_method == 'pip':
+                info('Installing requirements from: {}', installation_file)
                 python.pip('install', '-r', installation_file, quiet=True)
 
             elif installation_method == 'setuptools':
-                python.pip('install', '-e', git_repository_path(), quiet=True)
+                src_path = git_repository_path()
+
+                info('Installing directory: {}', src_path)
+                python.pip('install', '-e', src_path, quiet=True)
 
             else:
                 raise ValueError(
@@ -353,7 +359,8 @@ def install_source():
 
 def update_source(revision=None):
     """
-    Update application repository to the specified revision.
+    Update application repository to the specified revision,
+    defaults to the projects branch if not specified.
 
     :return: tuple(previous commit, current commit)
     """
@@ -361,7 +368,7 @@ def update_source(revision=None):
 
     if not revision:
         branch, revision = remote_head()
-        warn('No revision specified, assuming {} (from: {})'.format(revision, branch))
+        info('Fetched branch: {} rev: {}', branch, revision)
 
     with sudo_project():
         # Get current commit

--- a/blues/application/tasks.py
+++ b/blues/application/tasks.py
@@ -91,6 +91,9 @@ def deploy(revision=None, auto_reload=True, force=False, update_pip=False):
 
 @task
 def install_requirements():
+    """
+    Install requirements witihn a virtualenv
+    """
     from .deploy import install_requirements
     from .project import use_virtualenv
 
@@ -123,7 +126,8 @@ def deployed():
         origin = git.get_origin(repository_path)
         origin_commit, origin_message = git.log(repository_path, refspec=origin)[0]
         if head_commit != origin_commit:
-            info('Pending commit: {} comment: {}', origin_commit, origin_message)
+            info('Remote: {} commit: {} comment: {}',
+                 origin, origin_commit, origin_message)
 
         return head_commit, origin_commit
 
@@ -249,6 +253,11 @@ def generate_nginx_conf(role='www'):
 
 
 def get_github_owner():
+    """
+    Get the account/organization from the project's github url
+
+    :return str: account name
+    """
     from .project import git_repository
     from ..git import parse_url
 
@@ -260,6 +269,11 @@ def get_github_owner():
 
 
 def get_latest_release():
+    """
+    Get the latest tagged release from the remote repo
+
+    :return tuple: tag, revision
+    """
     from .project import latest_release
 
     info('Locating the latest release')
@@ -267,6 +281,11 @@ def get_latest_release():
 
 
 def notify_deploy_start(role=None, notifier=slack.notify, quiet=False):
+    """
+    Send a message to slack about the start of a deployment
+
+    :return str: formatted message
+    """
     from .project import project_name
 
     msg = '`{deployer}` started deploying '
@@ -293,6 +312,11 @@ def notify_deploy_start(role=None, notifier=slack.notify, quiet=False):
 
 
 def notify_deploy(role=None, commits=None, notifier=slack.notify, quiet=False):
+    """
+    Send a message to slack about a successful deployment
+
+    :return str: formatted message
+    """
     from .project import project_name, git_repository_path
 
     msg = '`{deployer}` deployed '

--- a/blues/application/tasks.py
+++ b/blues/application/tasks.py
@@ -259,6 +259,13 @@ def get_github_owner():
     return parse_url(url)['gh_owner']
 
 
+def get_latest_release():
+    from .project import latest_release
+
+    info('Locating the latest release')
+    return latest_release()
+
+
 def notify_deploy_start(role=None, notifier=slack.notify, quiet=False):
     from .project import project_name
 

--- a/blues/application/tasks.py
+++ b/blues/application/tasks.py
@@ -121,12 +121,12 @@ def deployed():
             info("Deployed tag: {}", head_tag)
 
         head_commit, head_message = git.log(repository_path)[0]
-        info('Deployed commit: {} comment: {}', head_commit, head_message)
+        info('Deployed revision: {} comment: {}', head_commit, head_message)
 
         origin = git.get_origin(repository_path)
         origin_commit, origin_message = git.log(repository_path, refspec=origin)[0]
         if head_commit != origin_commit:
-            info('Remote: {} commit: {} comment: {}',
+            info('Remote: {} revision: {} comment: {}',
                  origin, origin_commit, origin_message)
 
         return head_commit, origin_commit

--- a/blues/git.py
+++ b/blues/git.py
@@ -102,6 +102,24 @@ def fetch(repository_path=None):
         run('git fetch origin', pty=False)
 
 
+def lsremote(repo_url, reftype="branches"):
+    prefixes = {
+        'branches': 'refs/heads/',
+        'tags': 'refs/tags/'
+    }
+    prefix = prefixes[reftype]
+
+    with silent():
+        cmd = 'git -c color.ui=never --no-pager ls-remote {}'.format(repo_url)
+        output = local(cmd, capture=True)
+        ls = output.strip().split('\n')
+
+    pattern = r'(?P<hash>\w+)\s+(?P<label>[\w\.\-\/]+)'
+    return {match.group('label')[len(prefix):]: match.group('hash')
+            for match in map(lambda x: re.match(pattern, x), ls)
+            if match and match.group('label').startswith(prefix)}
+
+
 def show_file(repository_path, filename, revision='HEAD'):
     with cd(repository_path), silent():
         # pipe through cat to get rid of any ANSI codes
@@ -113,9 +131,9 @@ def show_file(repository_path, filename, revision='HEAD'):
     return output
 
 
-def reset(branch, repository_path=None, **kwargs):
+def reset(revision, repository_path=None, **kwargs):
     """
-    Fetch, reset, clean and checkout repository branch.
+    Fetch, reset, clean and checkout revision.
 
     :return: commit short hash or None
     """
@@ -126,7 +144,7 @@ def reset(branch, repository_path=None, **kwargs):
 
     with cd(repository_path):
         name = os.path.basename(repository_path)
-        info('Resetting git repository: {}@{}', name, branch or '<default>')
+        info('Resetting git repository: {}@{}', name, revision or 'HEAD')
 
         with silent('warnings'):
             commands = [
@@ -136,10 +154,8 @@ def reset(branch, repository_path=None, **kwargs):
                 'git clean {} -fdx'.format(' '.join(['-e {}'.format(ign)
                                                      for ign in ignore])),
                 'git checkout HEAD',  # Checkout HEAD
-                # Reset to the tip of remote branch, or the tip of the remote
-                # repository in case of no specified branch.
-                'git reset refs/remotes/origin/{} --hard'.format(
-                    branch or 'HEAD'),
+                # Reset to the specified revision, or the tip of the remote repository.
+                'git reset {} --hard'.format(revision or 'HEAD'),
             ]
 
             output = run(' && '.join(commands))
@@ -147,27 +163,10 @@ def reset(branch, repository_path=None, **kwargs):
         if output.return_code != 0:
             warn('Failed to reset repository "{}", probably permission denied!'
                  .format(name))
+            return None
+
         else:
-            # Pipe through cat in order to suppress non-text output from
-            # git-show. This includes terminal colors but also other
-            # terminal-stuff that is emitted by git-show if it prints to a
-            # terminal.
-            with silent('warnings'):
-                output = run('git show --oneline -s | cat')
-
-            match_commit = re.search(
-                r'(^|\n)(?P<commit>[0-9a-f]+)'
-                r'\s(?P<subject>.*)(\r|\n|$)',
-                output)
-
-            if match_commit is None:
-                raise ValueError('Cannot get commit info from output: %r' %
-                                 output)
-
-            commit = match_commit.group('commit')
-            subject = match_commit.group('subject')
-            info('HEAD is now at: {}', ' '.join([commit, subject]))
-
+            commit, _ = log()[0]
             return commit
 
 
@@ -183,10 +182,11 @@ def get_commit(repository_path=None, short=False):
         repository_path = debian.pwd()
 
     with cd(repository_path), silent():
-        output = run('git rev-parse HEAD')
-        commit = output.strip()
+        cmd = 'git rev-parse'
         if short:
-            commit = commit[:7]
+            cmd += ' --short'
+
+        commit = run('{} HEAD'.format(cmd)).strip()
 
     return commit
 
@@ -233,7 +233,17 @@ def diff_stat(repository_path=None, commit='HEAD^', path=None):
         return changed, insertions, deletions
 
 
-def log(repository_path=None, commit='HEAD', count=1, path=None):
+def get_origin(repository_path):
+    if not repository_path:
+        repository_path = debian.pwd()
+
+    with cd(repository_path), silent():
+        origin = run('git rev-parse --abbrev-ref --symbolic-full-name @{u}', pty=False)
+
+    return origin
+
+
+def log(repository_path=None, refspec='HEAD', count=1, path=None, author=False):
     """
     Get log for repository and optional commit range.
 
@@ -246,15 +256,21 @@ def log(repository_path=None, commit='HEAD', count=1, path=None):
         repository_path = debian.pwd()
 
     with cd(repository_path), silent():
-        cmd = 'git log --pretty=oneline {}'.format(commit)
+        cmd = 'git -c color.ui=never --no-pager log'
+        cmd += ' --pretty="format:%h {}"'.format('%an: %s' if author else '%s')
+
         if count:
-            cmd += ' -{}'.format(count)
+            cmd += ' -n{}'.format(count)
+
+        cmd += ' {}'.format(refspec)
+
         if path:
             cmd += ' -- {}'.format(path)
+
         output = run(cmd, pty=False)
-        git_log = output.stdout.strip()
-        git_log = [col.strip() for row in git_log.split('\n') for col in row.split(' ', 1) if col]
-        git_log = zip(git_log[::2], git_log[1::2])
+
+        git_log = output.stdout.strip().split('\n')
+        git_log = [row.split(' ', 1) for row in git_log]
 
     return git_log
 
@@ -266,29 +282,28 @@ def log_between_tags(repository_path, tag1, tag2):
     :param repository_path:
     :param tag1: oldest tag
     :param tag2: newset tag
-    :return: changelog in text
+    :return: changelog as a string
     """
-    with cd(repository_path):
-        cmd = 'git --no-pager log --pretty=oneline {0}..{1}'.format(
-            tag1, tag2)
-        # removes carriage return
-        changes = run(cmd).replace('\r', '')
-        return changes
+    refspec = '{0}..{1}'.format(tag1, tag2)
+    git_log = log(repository_path, refspec=refspec, count=False, author=True)
+    return u'\n'.join([u' :: '.join(row) for row in git_log])
 
 
 def current_tag(repository_path=None):
     """
     Get most recent tag
     :param repository_path: Repository path
-    :return: The most recent tag
+    :return: The most recent tag, and the number of commits from HEAD
     """
     if not repository_path:
         repository_path = debian.pwd()
+
     with cd(repository_path), silent():
         output = run('git describe --long --tags --dirty --always', pty=False)
-
         # 20141114.1-306-g72354ae-dirty
-        return output.strip().rsplit('-', 2)[0]
+        tag, delta, _ = output.strip().split('-')
+
+        return tag, int(delta)
 
 
 def get_two_most_recent_tags(repository_path):
@@ -345,7 +360,6 @@ def parse_url(url, branch=None):
             url_branch, egg = url_branch.split('#', 1)
 
     if url is None or not url:
-        import pdb; pdb.set_trace()
         raise ValueError('The git URL is not, have you set it correctly?')
 
     if branch is None:

--- a/blues/git.py
+++ b/blues/git.py
@@ -102,7 +102,14 @@ def fetch(repository_path=None):
         run('git fetch origin', pty=False)
 
 
-def lsremote(repo_url, reftype="branches"):
+def lsremote(repo_url, reftype='branches'):
+    """
+    Get references from a remote repository.
+    :param reftype: the reference types to return: 'branches' or 'tags'
+
+    :return dict: {reference: revision, ...}
+    """
+
     prefixes = {
         'branches': 'refs/heads/',
         'tags': 'refs/tags/'
@@ -121,6 +128,11 @@ def lsremote(repo_url, reftype="branches"):
 
 
 def show_file(repository_path, filename, revision='HEAD'):
+    """
+    Get the contents of a file from a specific revision
+
+    :return str: file contents
+    """
     with cd(repository_path), silent():
         # pipe through cat to get rid of any ANSI codes
         output = run('git show {revision}:{filename} | cat'.format(
@@ -135,7 +147,7 @@ def reset(revision, repository_path=None, **kwargs):
     """
     Fetch, reset, clean and checkout revision.
 
-    :return: commit short hash or None
+    :return str: commit short hash
     """
     if not repository_path:
         repository_path = debian.pwd()
@@ -176,7 +188,7 @@ def get_commit(repository_path=None, short=False):
 
     :param repository_path: Repository path
     :param short: Format git commit hash in short (7) format
-    :return: Commit hash
+    :return str: Commit hash
     """
     if not repository_path:
         repository_path = debian.pwd()
@@ -192,6 +204,11 @@ def get_commit(repository_path=None, short=False):
 
 
 def get_local_commiter():
+    """
+    Retrieves the calling user's git name
+
+    :return str: username
+    """
     return local('git config user.name', capture=True)
 
 
@@ -202,7 +219,7 @@ def diff_stat(repository_path=None, commit='HEAD^', path=None):
     :param repository_path: Repository path
     :param commit: Commit to diff against, ex 12345..67890
     :param path: Path or file to diff
-    :return: tuple(num files changed, num insertions, num deletions)
+    :return tuple: int(files changed), int(insertions), int(deletions)
     """
     if not repository_path:
         repository_path = debian.pwd()
@@ -234,6 +251,11 @@ def diff_stat(repository_path=None, commit='HEAD^', path=None):
 
 
 def get_origin(repository_path):
+    """
+    Get the name of the remote (tracking) branch
+
+    :return str: refspec
+    """
     if not repository_path:
         repository_path = debian.pwd()
 

--- a/blues/newrelic.py
+++ b/blues/newrelic.py
@@ -146,7 +146,7 @@ def send_deploy_event(payload=None):
 
         if not payload:
             path = python_path()
-            commit_hash = git.get_commit(path)
+            commit_hash = git.get_commit(path, short=True)
             new_tag, old_tag = git.get_two_most_recent_tags(path)
             changes = git.log_between_tags(path, old_tag, new_tag)
             deployer = git.get_local_commiter()

--- a/blues/python.py
+++ b/blues/python.py
@@ -95,7 +95,7 @@ def pip(command, *options, **kwargs):
     # TODO: change pip log location, per env? per user?
     # Perhaps we should just remove the log_file argument and let pip put it
     # where it belongs.
-    info('Running pip {}', command)
+    info('Running pip {} {}', command, ' '.join(options))
     bin = kwargs.pop('bin',
                      'pip3' if requested_version() >= (3,)
                      else 'pip')
@@ -110,6 +110,6 @@ def pip(command, *options, **kwargs):
 
 
 @task
-def update_pip():
+def update_pip(quiet=False):
     info('Updating pip')
-    pip('install -U pip')
+    pip('install', '-U', 'pip', quiet=quiet)


### PR DESCRIPTION
* Backwards-compatible with naive branch deployment,
* Numerious under-the-hood improvements for git-related tasks
* More readable output
* Uses short hashes by default (easier to compare visually)