### PR TITLE
Move docker.service, ln to old path

### DIFF
--- a/blues/docker.py
+++ b/blues/docker.py
@@ -73,7 +73,11 @@ def install():
 
         else:
             blueprint.upload('./docker.service',
-                             '/etc/systemd/system/multi-user.target.wants/docker.service')
+                             '/etc/systemd/system/docker.service')
+            debian.ln(
+                '/etc/systemd/system/docker.service',
+                '/etc/systemd/system/multi-user.target.wants/docker.service',
+            )
             debian.systemd_daemon_reload()
 
 


### PR DESCRIPTION
Systemd seems not to find it and therefore defaults to the vendor conf
in /lib/systemd/...

(Untested.)