### PR TITLE
Ops-809_elastic: Update blueprints for Elasticsearch 7.x

### DIFF
--- a/blues/debian.py
+++ b/blues/debian.py
@@ -403,19 +403,19 @@ def systemd_service(name, action='is-enabled'):
 
 
 def add_rc_service(name, priorities='defaults'):
-    if lsb_release() == '16.04':
-        systemd_service(name, 'enable')
+    if lsb_release() == '14.04':
+        update_rc(name, priorities)
 
     else:
-        update_rc(name, priorities)
+        systemd_service(name, 'enable')
 
 
 def remove_rc_service(name):
-    if lsb_release() == '16.04':
-        systemd_service(name, 'disable')
+    if lsb_release() == '14.04':
+        update_rc(name, priorities='remove', force=True)
 
     else:
-        update_rc(name, priorities='remove', force=True)
+        systemd_service(name, 'disable')
 
 
 @task

--- a/blues/elasticsearch.py
+++ b/blues/elasticsearch.py
@@ -76,11 +76,13 @@ def add_elastic_repo(branch):
 
 def install():
     with sudo():
-        from blues import java
-        java.install()
-
         branch = blueprint.get('branch', '6.x')
         add_elastic_repo(branch)
+
+        # ES 7 and higher bundles java
+        if branch == '6.x':
+            from blues import java
+            java.install()
 
         version = blueprint.get('version', 'latest')
         info('Installing {} version {}', 'elasticsearch', version)

--- a/blues/java.py
+++ b/blues/java.py
@@ -42,7 +42,7 @@ def install():
     with sudo():
         lsb_release = debian.lsb_release()
 
-        if lsb_release in ('14.04', '16.04'):
+        if lsb_release in ('14.04', '16.04', '18.04'):
             debian.add_apt_ppa('webupd8team/java', src=True)
             debian.debconf_set_selections(
                 'shared/accepted-oracle-license-v1-1 select true',

--- a/blues/templates/elasticsearch/default
+++ b/blues/templates/elasticsearch/default
@@ -36,7 +36,7 @@ ES_STARTUP_SLEEP_TIME=5
 # Specifies the maximum file descriptor number that can be opened by this process
 # When using Systemd, this setting is ignored and the LimitNOFILE defined in
 # /usr/lib/systemd/system/elasticsearch.service takes precedence
-#MAX_OPEN_FILES=65536
+#MAX_OPEN_FILES=65535
 
 # The maximum number of bytes of memory that may be locked into RAM
 # Set to "unlimited" if you use the 'bootstrap.memory_lock: true' option

--- a/blues/templates/elasticsearch/elasticsearch.yml
+++ b/blues/templates/elasticsearch/elasticsearch.yml
@@ -39,6 +39,11 @@ node.data: {{ node_data }}
 # Path to directory where to store the data (separate multiple locations by comma):
 #
 path.data: {{ data_path }}
+{% if repos %}
+#
+# Path to repositories:
+path.repo: {{ repos }}
+{% endif %}
 #
 # Path to log files:
 #
@@ -79,6 +84,7 @@ network.host: {{ network_host }}
 # Bootstrap the cluster using an initial set of master-eligible nodes:
 #
 #cluster.initial_master_nodes: ["node-1", "node-2"]
+{% if zen_unicast_hosts %}cluster.initial_master_nodes: {{ zen_unicast_hosts }}{% endif %}
 #
 # For more information, consult the discovery and cluster formation module documentation.
 #

--- a/blues/templates/elasticsearch/elasticsearch.yml
+++ b/blues/templates/elasticsearch/elasticsearch.yml
@@ -1,7 +1,14 @@
 # ======================== Elasticsearch Configuration =========================
 #
-# Please see the documentation for further information on configuration options:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html>
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please consult the documentation for further information on configuration options:
+# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
 #
 # ---------------------------------- Cluster -----------------------------------
 #
@@ -14,6 +21,10 @@ cluster.name: {{ cluster_name }}
 # Use a descriptive name for the node:
 #
 node.name: {{ node_name }}
+#
+# Add custom attributes to the node:
+#
+#node.attr.rack: r1
 #
 # Allow this node to be eligible as a master node (enabled by default):
 #
@@ -29,6 +40,8 @@ node.data: {{ node_data }}
 #
 path.data: {{ data_path }}
 #
+# Path to log files:
+#
 path.logs: /var/log/elasticsearch
 #
 # ----------------------------------- Memory -----------------------------------
@@ -37,49 +50,57 @@ path.logs: /var/log/elasticsearch
 #
 bootstrap.memory_lock: {{ memory_lock }}
 #
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
 # ---------------------------------- Network -----------------------------------
 #
 # Set the bind address to a specific IP (IPv4 or IPv6):
 #
 network.host: {{ network_host }}
 #
+# Set a custom port for HTTP:
+#
+#http.port: 9200
+#
+# For more information, consult the network module documentation.
+#
 # --------------------------------- Discovery ----------------------------------
 #
-# Pass an initial list of hosts to perform discovery when new node is started:
+# Pass an initial list of hosts to perform discovery when this node is started:
 # The default list of hosts is ["127.0.0.1", "[::1]"]
 #
 # discovery.zen.ping.unicast.hosts: []
 {% if zen_unicast_hosts %}discovery.zen.ping.unicast.hosts: {{ zen_unicast_hosts }}{% endif %}
 #
-# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+# Bootstrap the cluster using an initial set of master-eligible nodes:
 #
-# discovery.zen.minimum_master_nodes: 3
+#cluster.initial_master_nodes: ["node-1", "node-2"]
+#
+# For more information, consult the discovery and cluster formation module documentation.
 #
 # ---------------------------------- Gateway -----------------------------------
 #
 # Block initial recovery after a full cluster restart until N nodes are started:
 #
-# gateway.recover_after_nodes: 3
-#
-# Set how many nodes are expected in this cluster
-#
-# gateway.expected_nodes: 2
+#gateway.recover_after_nodes: 3
 {% if cluster_size %}gateway.expected_nodes: {{ cluster_size }}{% endif %}
+#
+# For more information, consult the gateway module documentation.
 #
 # ---------------------------------- Various -----------------------------------
 #
-# Disable starting multiple nodes on a single system:
-#
-# node.max_local_storage_nodes: 1
-#
 # Require explicit names when deleting indices:
 #
-# action.destructive_requires_name: true
+#action.destructive_requires_name: true
 #
 # Threading optimization
 #
 thread_pool.search.queue_size: {{ queue_size }}
 #
-thread_pool.bulk.queue_size: {{ queue_size }}
+thread_pool.write.queue_size: {{ queue_size }}
 #
 # ------------------------------------------------------------------------------

--- a/blues/templates/elasticsearch/jvm.options
+++ b/blues/templates/elasticsearch/jvm.options
@@ -37,6 +37,23 @@
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
 
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+# 10-:-XX:+UseG1GC
+# 10-:-XX:InitiatingHeapOccupancyPercent=75
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
 ## optimizations
 
 # pre-touch memory pages used by the JVM during initialization
@@ -100,6 +117,3 @@
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
 9-:-Djava.locale.providers=COMPAT
-
-# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
-10-:-XX:UseAVX=2


### PR DESCRIPTION
Rebasing all the configs with the latest default configs while keeping all the active values (with the exception of thread_pool.bulk.queue_size which hasn't been around since ES 5.x)

ES 7.x comes with a bundled OpenJDK so I removed Oracles Java on non-6.x versions of ES.

Added support for managing snapshot repositories through fabric.