### PR TITLE
OPS-810_prod_elastic: Add support for GCS backends

### DIFF
--- a/blues/bind.py
+++ b/blues/bind.py
@@ -131,3 +131,4 @@ def configure(force_reload=False):
 
         if uploads or force_reload:
             reload()
+        info('If the records to not start resolving properly\nRun "rndc refresh <zone>" on the DNS slaves\n(Hades and Chaos)')

--- a/blues/bind.py
+++ b/blues/bind.py
@@ -131,4 +131,4 @@ def configure(force_reload=False):
 
         if uploads or force_reload:
             reload()
-        info('If the records to not start resolving properly\nRun "rndc refresh <zone>" on the DNS slaves\n(Hades and Chaos)')
+        info('If the records do not start resolving properly,\nRun "rndc refresh <zone>" on the DNS slaves (Hades and Chaos)')

--- a/blues/debian.py
+++ b/blues/debian.py
@@ -616,7 +616,7 @@ def disable_swap():
             output = run(r"cat /etc/fstab | grep '{}' || true".format(regex_match))
             fstab = output.stdout
             if fstab:
-                info('Disabling the following mount points: \n {}'.format(fstab))
+                info('Disabling the following mount points:\n{}'.format(fstab))
                 run(r"sed -i '/{}/ s/^/#/' /etc/fstab".format(regex_match))
                 info('Turning off live swap')
                 run('swapoff -a || true')

--- a/blues/debian.py
+++ b/blues/debian.py
@@ -606,6 +606,22 @@ def add_fstab(filesystem=None, mount_point=None, type='auto', options='rw', dump
         if mounted_file_system and mounted_file_system != filesystem:
             unmount(mount_point)
 
+def disable_swap():
+    """
+    Disable swap and remove swap configuration from /etc/fstab.
+    """
+    with sudo():
+        with silent():
+            regex_match = r'^[^#].*\sswap\s'
+            output = run(r"cat /etc/fstab | grep '{}' || true".format(regex_match))
+            fstab = output.stdout
+            if fstab:
+                info('Disabling the following mount points: \n {}'.format(fstab))
+                run(r"sed -i '/{}/ s/^/#/' /etc/fstab".format(regex_match))
+                info('Turning off live swap')
+                run('swapoff -a || true')
+            
+
 def validate_boot_options(options):
     """
     Validate systemd boot options

--- a/blues/elasticsearch.py
+++ b/blues/elasticsearch.py
@@ -152,6 +152,11 @@ def configure():
     service_dir = "/etc/systemd/system/elasticsearch.service.d"
 
     debian.mkdir(service_dir)
+
+    disable_swap = blueprint.get('node.disable_swap', False)
+    if disable_swap:
+        debian.disable_swap()
+
     changes += blueprint.upload('./override.conf', service_dir + '/override.conf', context)
 
     if changes:

--- a/blues/elasticsearch.py
+++ b/blues/elasticsearch.py
@@ -184,8 +184,15 @@ def add_gcs_credentials():
     with sudo():
         run('{}elasticsearch-keystore add-file gcs.client.{}.credentials_file {}'.format(bin_path, client, cred_file))
         run('rm {} {}.md5'.format(cred_file, cred_file))
+        
         reload_url = 'http://{}:9200/_nodes/reload_secure_settings'.format(node_name)
-        requests.post(url = reload_url)
+        reload_reply = requests.post(url = reload_url)
+
+        status_code = reload_reply.status_code
+            
+        if status_code != 200:
+            abort("Could not reload keystore\nstatus code: {}\nmessage:\n{}".format(
+                status_code, reload_reply.text))
 
 @task
 def add_elastic_snapshot_repos():

--- a/blues/elasticsearch.py
+++ b/blues/elasticsearch.py
@@ -42,7 +42,7 @@ from . import debian
 from refabric.operations import run
 
 __all__ = ['start', 'stop', 'restart', 'reload', 'setup', 'configure',
-           'install_plugin', 'add_elastic_snapshot_repos']
+           'install_plugin', 'add_elastic_snapshot_repos', 'add_gcs_credentials']
 
 
 blueprint = blueprints.get(__name__)
@@ -119,7 +119,8 @@ def configure():
     repo_locations = []
     if cluster_repos:
         for repo in cluster_repos:
-            repo_locations.append('"{}"'.format(cluster_repos[repo]['location']))
+            if cluster_repos[repo]['type'] == 'fs':
+                repo_locations.append('"{}"'.format(cluster_repos[repo]['location']))
     repo_locations = '[ {} ]'.format(", ".join(repo_locations))
 
     changes = []
@@ -162,6 +163,29 @@ def configure():
     if changes:
         restart()
 
+@task
+def add_gcs_credentials():
+    import requests
+    from fabric.state import env
+
+    with silent():
+        hostname = debian.hostname()
+    node_name = blueprint.get('node.name', hostname)
+
+    cred_file = '/scs-elastic-snapshots-user.json'
+    bin_path = '/usr/share/elasticsearch/bin/'
+
+
+    blueprint.upload('./{}/scs-elastic-snapshots-user.json'.format(env.state),
+                    cred_file, user='root', group='root')
+
+    client = 'default'
+
+    with sudo():
+        run('{}elasticsearch-keystore add-file gcs.client.{}.credentials_file {}'.format(bin_path, client, cred_file))
+        run('rm {} {}.md5'.format(cred_file, cred_file))
+        reload_url = 'http://{}:9200/_nodes/reload_secure_settings'.format(node_name)
+        requests.post(url = reload_url)
 
 @task
 def add_elastic_snapshot_repos():
@@ -177,14 +201,29 @@ def add_elastic_snapshot_repos():
 
         if repocheck.status_code == 404:
             info("Adding elastic snapshot repository '{}'".format(repo))
-
             url = 'http://{}:9200/_snapshot/{}'.format(node_name, repo)
-            body = {
-                "type": repos[repo]['type'],
-                "settings": {
-                    "location": repos[repo]['location']
+
+            if repos[repo]['type'] == 'gcs':
+
+                if 'client' in repos[repo]:
+                    client = repos[repo]['client']
+                else:
+                    client = 'default'
+
+                body = {
+                    "type": 'gcs',
+                    "settings": {
+                        "bucket": repos[repo]['bucket'],
+                        "client": client
+                    }
                 }
-            }
+            else:
+                body = {
+                    "type": repos[repo]['type'],
+                    "settings": {
+                        "location": repos[repo]['location']
+                    }
+                }
 
             repoadd_reply = requests.put(url = url, json = body)
             status_code = repoadd_reply.status_code
@@ -201,3 +240,4 @@ def install_plugin(name=None):
 
     with sudo():
         run('/usr/share/elasticsearch/bin/elasticsearch-plugin install {}'.format(name))
+        restart()


### PR DESCRIPTION
Add support for Google Cloud Storage for elastic snapshot repository backends and disable swap by default on elastic clusters