### PR TITLE
OPS-1199: kibana encryptionkey

### DIFF
--- a/blues/templates/kibana/kibana.yml
+++ b/blues/templates/kibana/kibana.yml
@@ -112,3 +112,5 @@ logging.dest: "/var/log/kibana/kibana.log"
 # The default locale. This locale can be used in certain circumstances to substitute any missing
 # translations.
 #i18n.defaultLocale: "en"
+
+xpack.reporting.encryptionKey: "P0jm8rsAmGgX4UJcAe9PApATM2fFx2"


### PR DESCRIPTION
Set xpack.reporting.encryptionKey to keep reports working across multiple instances/restarts of the Kibana service. Default behavior is a random string per instance and start.