### PR TITLE
OPS-1257: Avoid losing logs due to force closes

### DIFF
--- a/blues/beats.py
+++ b/blues/beats.py
@@ -134,7 +134,7 @@ def configure():
                     'logfile_type': doc_type
                 }
             }
-            input_conf["close_timeout"] = "15m" 
+            input_conf["close_timeout"] = "480m" 
             if isinstance(input_spec, list):
                 input_conf['paths'] = input_spec
             else:


### PR DESCRIPTION
Currently, we've got a bad combination of really talkative logfiles and low timeout threshold for filebeat. This possibly results in a lot of lost logs. 

I'm increasing the timeout from 15m to 8h. The default is infinite and the problem we had that caused us to add the limit was files sometimes being held open for days/weeks and filling the disk up even though the logfile had been rotated out and deleted. 

The real problem is that filebeat isn't all the way through the logfiles but I think this will also help.