### PR TITLE
OPS-1332: Prune only images old images

### DIFF
--- a/blues/templates/docker/docker-system-prune
+++ b/blues/templates/docker/docker-system-prune
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker system prune --all --force
+docker system prune --all --force --filter until=1500h


### PR DESCRIPTION
Docker swarm handles registry auth pretty badly so we should only prune older images to reduce these errors